### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,8 @@ Start command:
 ```bash
 uvicorn mcp_server:app --reload --host 0.0.0.0 --port 8000
 ````
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/wooonster-hocr-mcp-server).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/wooonster-hocr-mcp-server)